### PR TITLE
Removed non-7 bit ASCII character

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
    <name>map_msgs</name>
    <version>0.0.2</version>
    <description>This package defines messages commonly used in mapping packages.</description>
-   <maintainer email="stephane@magnenat.net">Stéphane Magnenat</maintainer>
+   <maintainer email="stephane@magnenat.net">Stephane Magnenat</maintainer>
 
    <license>BSD</license>
 


### PR DESCRIPTION
The é in Stéphane make catkin crash on my MacBook.

```
Traceback (most recent call last):
  File "/Users/dgossow/ros_catkin_ws/install_isolated/share/catkin/cmake/parse_package_xml.py", line 87, in <module>
    main()
  File "/Users/dgossow/ros_catkin_ws/install_isolated/share/catkin/cmake/parse_package_xml.py", line 81, in main
    lines = _get_output(package)
  File "/Users/dgossow/ros_catkin_ws/install_isolated/share/catkin/cmake/parse_package_xml.py", line 55, in _get_output
    values['MAINTAINER'] = '"%s"' % (', '.join([str(m) for m in package.maintainers]))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 2: ordinal not in range(128)
```
